### PR TITLE
Rails 6 expects a different mime type format

### DIFF
--- a/lib/jpbuilder-handler.rb
+++ b/lib/jpbuilder-handler.rb
@@ -2,17 +2,22 @@ require "jbuilder"
 
 class JPbuilderHandler
   cattr_accessor :default_format, :default_callback
-  self.default_format = Mime[:json]
-  self.default_callback = nil
 
-  def self.call(template)
+  def initialize
+    self.default_callback = nil
+    self.default_format = (Rails.version < '6.0.0') ? Mime[:json] : :json
+  end
+
+  def self.call(template, source=nil)
+    source ||= template.source
     %{
       if defined?(json)
-        #{template.source}
+        #{source}
       else
         result = JbuilderTemplate.encode(self) do |json|
-          #{template.source}
+          #{source}
         end
+        result = result.each_char.to_a.map { |chr| chr.ord > 1000 ? "\\\\u\#{"%4.4x" % chr.ord}" : chr }.join
         callback = params[:callback] || JPbuilderHandler.default_callback
         if callback.present?
           "/**/\#{callback}(\#{result});"


### PR DESCRIPTION
since the gem is unmaintained I borrowed the fix from:
https://github.com/bigjason/jpbuilder/pull/13